### PR TITLE
README emphasize the ncurses requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ nettop relies on *libpacap* to intercept all packets and deliver a copy to the a
 
 ### ncurses
 
-nettop relies on *ncurses* to facilitate the UI drawing on console; on Ubuntu-like systems please install `libncurses5-de` or more recent to allow compiling.
+nettop relies on *ncurses* to facilitate the UI drawing on console; on Ubuntu-like systems please install `libncurses5-dev` or more recent to allow compiling.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ nettop relies on *libpacap* to intercept all packets and deliver a copy to the a
 
 ### ncurses
 
-nettop relies on *ncurses* to facilitate the UI drawing on console; on Ubuntu-like systems please install *libncurses5-dev* or more recent to allow compiling.
+nettop relies on *ncurses* to facilitate the UI drawing on console; on Ubuntu-like systems please install ´libncurses5-dev´ or more recent to allow compiling.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ nettop relies on *libpacap* to intercept all packets and deliver a copy to the a
 
 ### ncurses
 
-nettop relies on *ncurses* to facilitate the UI drawing on console; on Ubuntu-like systems please install ´libncurses5-dev´ or more recent to allow compiling.
+nettop relies on *ncurses* to facilitate the UI drawing on console; on Ubuntu-like systems please install `libncurses5-de` or more recent to allow compiling.
 
 ## Running
 


### PR DESCRIPTION
The required libncurses5-dev library is now emphasized same is the libpcap library which makes it a bit easier to spot.