### PR TITLE
Fix compilation error for gcc11

### DIFF
--- a/src/name_res.cpp
+++ b/src/name_res.cpp
@@ -17,6 +17,7 @@
 *	along with nettop.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <memory>
 #include "name_res.h"
 
 void nettop::name_res::thread_proc(void) {


### PR DESCRIPTION
nettop didn't use to compile with gcc v11 (and probably some prior versions) due to lacking `<memory>` include. This solves that problem (https://github.com/Emanem/nettop/issues/7)