### PR TITLE
tv.tv_usec -> seconds needs to be divided by 1M

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -65,7 +65,7 @@ public:
         };
 
 	inline double tv_to_sec(const timeval& tv) {
-		return 1.0*tv.tv_sec + (1.0/1000000000.0)*tv.tv_usec;
+		return 1.0*tv.tv_sec + (1.0/1000000.0)*tv.tv_usec;
 	}
 }
 


### PR DESCRIPTION
fixed incorrect ts on captured packets (the usec part was divided by 1B instead of 1M)