### PR TITLE
Add support for Apple Silicon Macs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+nettop
+obj/

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,12 @@ $(OBJDIR)/__setup_obj_dir :
 	mkdir -p $(OBJDIR)
 	touch $(OBJDIR)/__setup_obj_dir
 
-.PHONY: clean bzip release
+.PHONY: clean bzip release setcap
+
+# grant packet-capture capabilities so a non-root user can run nettop (Linux only)
+setcap : $(EXEC)
+	sudo setcap cap_net_raw,cap_net_admin+eip $(EXEC)
+	getcap $(EXEC)
 
 clean :
 	rm -rf $(OBJDIR)/*.o

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ $(OBJDIR)/settings.o: src/settings.cpp src/settings.h src/utils.h $(OBJDIR)/__se
 
 $(OBJDIR)/main.o: src/main.cpp src/utils.h src/cap_mgr.h src/mt_list.h \
  src/packet_stats.h src/addr_t.h src/proc.h src/async_log.h \
- src/name_res.h src/settings.h src/epoll_stdin.h $(OBJDIR)/__setup_obj_dir
+ src/name_res.h src/settings.h src/poll_stdin.h $(OBJDIR)/__setup_obj_dir
 	$(CPPC) $(FLAGS) src/main.cpp -c -o $@
 
 $(OBJDIR)/packet_stats.o: src/packet_stats.cpp src/packet_stats.h src/addr_t.h \

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ SRCDIR=src
 OBJDIR=obj
 FLAGS=-g -Wall -std=c++11 -pthread 
 LIBS=-lpcap -lcurses 
+UNAME_S=$(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+LIBS+=-lproc
+endif
 OBJS=$(OBJDIR)/settings.o $(OBJDIR)/main.o $(OBJDIR)/packet_stats.o $(OBJDIR)/async_log.o $(OBJDIR)/proc.o $(OBJDIR)/name_res.o $(OBJDIR)/cap_mgr.o 
 EXEC=nettop
 DATE=$(shell date +"%Y-%m-%d")
@@ -39,7 +43,7 @@ $(OBJDIR)/name_res.o: src/name_res.cpp src/name_res.h src/addr_t.h src/mt_list.h
 	$(CPPC) $(FLAGS) src/name_res.cpp -c -o $@
 
 $(OBJDIR)/cap_mgr.o: src/cap_mgr.cpp src/cap_mgr.h src/mt_list.h src/packet_stats.h \
- src/addr_t.h src/utils.h $(OBJDIR)/__setup_obj_dir
+ src/addr_t.h src/utils.h src/settings.h $(OBJDIR)/__setup_obj_dir
 	$(CPPC) $(FLAGS) src/cap_mgr.cpp -c -o $@
 
 $(OBJDIR)/__setup_obj_dir :
@@ -58,4 +62,3 @@ bzip :
 
 release : FLAGS +=-O3 -D_RELEASE
 release : $(EXEC)
-

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Utility to show network traffic (both TCP and UDP v4 and v6) split by process an
 Download the repository and invoke `make` (`make release` for optimized build - *reccomended* when you want to use it properly and not degbugging/experimenting with it).
 Please note you need to have some dependencies satisfied (see following).
 
+On macOS, the system libpcap, ncurses, and libproc libraries provided by the Command Line Tools are used. Invoke `make release` from the repository root.
+
 ### libpcap
 
 nettop relies on *libpacap* to intercept all packets and deliver a copy to the application. On Ubuntu and Debian derivatives you should install the *-dev* version (i.e. `sudo apt install libpcap-dev`).
@@ -32,6 +34,7 @@ Executes nettop 0.5
     --tcp-udp-split		Displays split of TCP and UDP traffic in % (default not set)
 -n, --no-resolve		Do not resolve addresses, leave IPs to be displayed
 -a, --async-log-file (file)	Sets an output file where to store the packets attribued to the 'kernel' (default not set)
+-i, --interface (iface)		Capture on a specific network interface (default auto)
 -l, --limit-hosts-rows		Limits maximum number of hosts rows per pid (default no limit)
     --help			prints this help and exit
 
@@ -48,6 +51,8 @@ This will start nettop and split between TCP and UDP usage, limiting how many ho
 ### *sudo* requirements
 
 Please note nettop needs to have *root* privileges to intercept all packets incoming and outgoing from current computer. Without *root* access it's unlikely to run.
+
+On macOS, use `sudo ./nettop --interface en0` or replace `en0` with another interface such as `lo0` or a `utun` interface. Without sufficient BPF permissions, macOS will report `cannot open BPF device`.
 
 ## F.A.Q.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Executes nettop 0.5
     --filter-zero		Set to filter all zero results (default not set)
     --tcp-udp-split		Displays split of TCP and UDP traffic in % (default not set)
 -n, --no-resolve		Do not resolve addresses, leave IPs to be displayed
+    --show-host-ip		Display numeric IP below resolved host names (default not set)
 -a, --async-log-file (file)	Sets an output file where to store the packets attribued to the 'kernel' (default not set)
 -i, --interface (iface)		Capture on a specific network interface (default auto)
 -l, --limit-hosts-rows		Limits maximum number of hosts rows per pid (default no limit)

--- a/src/cap_mgr.cpp
+++ b/src/cap_mgr.cpp
@@ -24,14 +24,39 @@
 #include <netinet/ip6.h>
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
+#include <net/ethernet.h>
+#include <arpa/inet.h>
 #include <chrono>
 #include <thread>
 #include <atomic>
+#include <cstring>
+#include <string>
 #include "addr_t.h"
+#include "settings.h"
 
 namespace {
 
 	typedef std::list<nettop::packet_stats>	st_pkt_list;
+
+#ifdef __APPLE__
+	inline uint16_t tcp_src_port(const struct tcphdr *tcp) { return ntohs(tcp->th_sport); }
+	inline uint16_t tcp_dst_port(const struct tcphdr *tcp) { return ntohs(tcp->th_dport); }
+	inline uint16_t udp_src_port(const struct udphdr *udp) { return ntohs(udp->uh_sport); }
+	inline uint16_t udp_dst_port(const struct udphdr *udp) { return ntohs(udp->uh_dport); }
+#else
+	inline uint16_t tcp_src_port(const struct tcphdr *tcp) { return ntohs(tcp->source); }
+	inline uint16_t tcp_dst_port(const struct tcphdr *tcp) { return ntohs(tcp->dest); }
+	inline uint16_t udp_src_port(const struct udphdr *udp) { return ntohs(udp->source); }
+	inline uint16_t udp_dst_port(const struct udphdr *udp) { return ntohs(udp->dest); }
+#endif
+
+	struct cap_ctx {
+		st_pkt_list	p_list;
+		const int	link_type;
+
+		cap_ctx(const int link_type_) : link_type(link_type_) {
+		}
+	};
 
 	// linux cooked header
 	// glanced from libpcap/ssl.h
@@ -46,30 +71,39 @@ namespace {
         	u_int16_t	sll_protocol;         /* protocol */
 	};
 
-	inline void process_tcp(const u_char *data, st_pkt_list& p_list, const double ts, const size_t len, const addr_t& src, const addr_t& dst) {
+	inline void process_tcp(const u_char *data, const size_t avail, st_pkt_list& p_list, const double ts, const size_t len, const addr_t& src, const addr_t& dst) {
+		if(avail < sizeof(struct tcphdr))
+			return;
 		const struct tcphdr	*tcp = (struct tcphdr*)data;
-		const uint16_t		p_src = ntohs(tcp->source),
-					p_dst = ntohs(tcp->dest);
+		const uint16_t		p_src = tcp_src_port(tcp),
+					p_dst = tcp_dst_port(tcp);
 		p_list.push_back(nettop::packet_stats(src, dst, p_src, p_dst, len, nettop::packet_stats::type::PACKET_TCP, ts));
 	}
 
-	inline void process_udp(const u_char *data, st_pkt_list& p_list, const double ts, const size_t len, const addr_t& src, const addr_t& dst) {
+	inline void process_udp(const u_char *data, const size_t avail, st_pkt_list& p_list, const double ts, const size_t len, const addr_t& src, const addr_t& dst) {
+		if(avail < sizeof(struct udphdr))
+			return;
 		const struct udphdr	*udp = (struct udphdr*)data;
-		const uint16_t		p_src = ntohs(udp->source),
-					p_dst = ntohs(udp->dest);
+		const uint16_t		p_src = udp_src_port(udp),
+					p_dst = udp_dst_port(udp);
 		p_list.push_back(nettop::packet_stats(src, dst, p_src, p_dst, len, nettop::packet_stats::type::PACKET_UDP, ts));
 	}
 
-	inline void process_ip(const u_char *data, st_pkt_list& p_list, const double ts, const size_t len) {
+	inline void process_ip(const u_char *data, const size_t avail, st_pkt_list& p_list, const double ts, const size_t len) {
+		if(avail < sizeof(struct ip))
+			return;
 		const struct ip *ip = (struct ip*)data;
+		const size_t ip_hl = ip->ip_hl*4;
+		if(ip_hl < sizeof(struct ip) || avail < ip_hl)
+			return;
 		const addr_t	src(ip->ip_src),
 				dst(ip->ip_dst);
 		switch(ip->ip_p) {
 			case IPPROTO_TCP:
-				process_tcp(data + sizeof(struct ip), p_list, ts, len, src, dst);
+				process_tcp(data + ip_hl, avail - ip_hl, p_list, ts, len, src, dst);
 				break;
 			case IPPROTO_UDP:
-				process_udp(data + sizeof(struct ip), p_list, ts, len, src, dst);
+				process_udp(data + ip_hl, avail - ip_hl, p_list, ts, len, src, dst);
 				break;
 			default:
 				//std::cerr << "Unknown ip protocol " << (int)ip->ip_p << ", skipping packet" << std::endl;
@@ -77,16 +111,18 @@ namespace {
 		}
 	}
 
-	inline void process_ip6(const u_char *data, st_pkt_list& p_list, const double ts, const size_t len) {
+	inline void process_ip6(const u_char *data, const size_t avail, st_pkt_list& p_list, const double ts, const size_t len) {
+		if(avail < sizeof(struct ip6_hdr))
+			return;
 		const struct ip6_hdr	*ip6 = (struct ip6_hdr*)data;
 		const addr_t		src(ip6->ip6_src),
 					dst(ip6->ip6_dst);
 		switch(ip6->ip6_nxt) {
 			case IPPROTO_TCP:
-				process_tcp(data + sizeof(struct ip6_hdr), p_list, ts, len, src, dst);
+				process_tcp(data + sizeof(struct ip6_hdr), avail - sizeof(struct ip6_hdr), p_list, ts, len, src, dst);
 				break;
 			case IPPROTO_UDP:
-				process_udp(data + sizeof(struct ip6_hdr), p_list, ts, len, src, dst);
+				process_udp(data + sizeof(struct ip6_hdr), avail - sizeof(struct ip6_hdr), p_list, ts, len, src, dst);
 				break;
 			default:
 				//std::cerr << "Unknown ip protocol " << (int)ip6->ip6_nxt << ", skipping packet" << std::endl;
@@ -94,35 +130,169 @@ namespace {
 		}
 	}
 
-	void p_handler(u_char *user, const struct pcap_pkthdr *header, const u_char *data) {
+	inline void process_raw_ip(const u_char *data, const size_t avail, st_pkt_list& p_list, const double ts, const size_t len) {
+		if(avail < 1)
+			return;
+		switch(data[0] >> 4) {
+			case 4:
+				process_ip(data, avail, p_list, ts, len);
+				break;
+			case 6:
+				process_ip6(data, avail, p_list, ts, len);
+				break;
+			default:
+				break;
+		}
+	}
+
+	inline void process_ethernet(const u_char *data, const size_t avail, st_pkt_list& p_list, const double ts, const size_t len) {
+		if(avail < ETHER_HDR_LEN)
+			return;
+		const struct ether_header	*eth = (struct ether_header*)data;
+		uint16_t			ether_type = ntohs(eth->ether_type);
+		size_t				offset = ETHER_HDR_LEN;
+		while(ether_type == ETHERTYPE_VLAN || ether_type == 0x88a8) {
+			if(avail < offset + 4)
+				return;
+			uint16_t next_type = 0;
+			std::memcpy(&next_type, data + offset + 2, sizeof(next_type));
+			ether_type = ntohs(next_type);
+			offset += 4;
+		}
+		if(avail < offset)
+			return;
+		switch(ether_type) {
+			case ETHERTYPE_IP:
+				process_ip(data + offset, avail - offset, p_list, ts, len);
+				break;
+			case ETHERTYPE_IPV6:
+				process_ip6(data + offset, avail - offset, p_list, ts, len);
+				break;
+			default:
+				break;
+		}
+	}
+
+	inline void process_loopback(const u_char *data, const size_t avail, st_pkt_list& p_list, const double ts, const size_t len, const bool network_order) {
+		if(avail < sizeof(uint32_t))
+			return;
+		uint32_t family = 0;
+		std::memcpy(&family, data, sizeof(family));
+		if(network_order)
+			family = ntohl(family);
+		switch(family) {
+			case AF_INET:
+				process_ip(data + sizeof(uint32_t), avail - sizeof(uint32_t), p_list, ts, len);
+				break;
+			case AF_INET6:
+				process_ip6(data + sizeof(uint32_t), avail - sizeof(uint32_t), p_list, ts, len);
+				break;
+			default:
+				break;
+		}
+	}
+
+	inline void process_sll(const u_char *data, const size_t avail, st_pkt_list& p_list, const double ts, const size_t len) {
+		if(avail < sizeof(struct sll_header))
+			return;
 		const struct sll_header *sll = (struct sll_header*)data;
-		st_pkt_list& 		p_list = *(st_pkt_list*)user;
-		const double		ts = nettop::tv_to_sec(header->ts);
 		switch(sll->sll_protocol) {
 			case SLL_PROTOCOL_IP:
-				process_ip(data + sizeof(struct sll_header), p_list, ts, header->len);
+				process_ip(data + sizeof(struct sll_header), avail - sizeof(struct sll_header), p_list, ts, len);
 				break;
 			case SLL_PROTOCOL_IP6:
-				process_ip6(data + sizeof(struct sll_header), p_list, ts, header->len);
+				process_ip6(data + sizeof(struct sll_header), avail - sizeof(struct sll_header), p_list, ts, len);
 				break;
 			default:
 				//std::cerr << "Unknown SLL protocol " << (int)sll->sll_protocol << ", skipping packet" << std::endl;
 				break;
 		}
 	}
+
+	void p_handler(u_char *user, const struct pcap_pkthdr *header, const u_char *data) {
+		cap_ctx& 		ctx = *(cap_ctx*)user;
+		const double		ts = nettop::tv_to_sec(header->ts);
+		switch(ctx.link_type) {
+			case DLT_LINUX_SLL:
+				process_sll(data, header->caplen, ctx.p_list, ts, header->len);
+				break;
+			case DLT_EN10MB:
+				process_ethernet(data, header->caplen, ctx.p_list, ts, header->len);
+				break;
+			case DLT_NULL:
+				process_loopback(data, header->caplen, ctx.p_list, ts, header->len, false);
+				break;
+			case DLT_LOOP:
+				process_loopback(data, header->caplen, ctx.p_list, ts, header->len, true);
+				break;
+			case DLT_RAW:
+				process_raw_ip(data, header->caplen, ctx.p_list, ts, header->len);
+				break;
+			default:
+				break;
+		}
+	}
+
+#ifdef __APPLE__
+	std::string choose_device() {
+		if(!nettop::settings::INTERFACE.empty())
+			return nettop::settings::INTERFACE;
+
+		char		err[PCAP_ERRBUF_SIZE+1] = {0};
+		pcap_if_t	*devs = 0;
+		if(-1 == pcap_findalldevs(&devs, err))
+			throw nettop::runtime_error(err);
+		std::string	fallback,
+				selected;
+		for(pcap_if_t *dev = devs; dev; dev = dev->next) {
+			if(!dev->name)
+				continue;
+			if(fallback.empty())
+				fallback = dev->name;
+			bool has_ip = false;
+			for(pcap_addr_t *addr = dev->addresses; addr; addr = addr->next) {
+				if(addr->addr && (addr->addr->sa_family == AF_INET || addr->addr->sa_family == AF_INET6)) {
+					has_ip = true;
+					break;
+				}
+			}
+			if(has_ip && !(dev->flags & PCAP_IF_LOOPBACK)) {
+				selected = dev->name;
+				break;
+			}
+		}
+		if(selected.empty())
+			selected = fallback;
+		pcap_freealldevs(devs);
+		if(selected.empty())
+			throw nettop::runtime_error("No libpcap capture device found");
+		return selected;
+	}
+#endif
 }
 
-nettop::cap_mgr::cap_mgr() : p_(0) {
+nettop::cap_mgr::cap_mgr() : p_(0), link_type_(0) {
 	// open all network devices
 	char	err[PCAP_ERRBUF_SIZE+1];
-	p_ = pcap_open_live(NULL, BUFSIZ, 0, 250, err);
+#ifdef __APPLE__
+	const std::string	dev = choose_device();
+	p_ = pcap_open_live(dev.c_str(), BUFSIZ, 0, 250, err);
+#else
+	p_ = pcap_open_live(nettop::settings::INTERFACE.empty() ? NULL : nettop::settings::INTERFACE.c_str(), BUFSIZ, 0, 250, err);
+#endif
 	if(!p_)
 		throw runtime_error(err);
-	// only support Linux Cooked Socket link!
-	const int link_type = pcap_datalink(p_);
-	if(DLT_LINUX_SLL != link_type) {
+	link_type_ = pcap_datalink(p_);
+	switch(link_type_) {
+		case DLT_LINUX_SLL:
+		case DLT_EN10MB:
+		case DLT_NULL:
+		case DLT_LOOP:
+		case DLT_RAW:
+			break;
+		default:
 		pcap_close(p_);
-		throw runtime_error("Link type: ") << link_type << ", only DLT_LINUX_SLL (" << DLT_LINUX_SLL << ") supported!";
+			throw runtime_error("Link type: ") << link_type_ << " is not supported by this build";
 	}
 }
 
@@ -131,12 +301,12 @@ nettop::cap_mgr::~cap_mgr() {
 }
 
 void nettop::cap_mgr::capture_dispatch(packet_list& p_list) {
-	st_pkt_list	lcl_list;
-	const int dres = pcap_dispatch(p_, -1, p_handler, (u_char*)&lcl_list);
+	cap_ctx		ctx(link_type_);
+	const int dres = pcap_dispatch(p_, -1, p_handler, (u_char*)&ctx);
 	// we never call pcap_breakloop
 	if(-1 == dres)
 		throw runtime_error(pcap_geterr(p_));
-	p_list.push_many(lcl_list);
+	p_list.push_many(ctx.p_list);
 	p_list.total_pkts += dres;
 }
 
@@ -145,4 +315,3 @@ void nettop::cap_mgr::async_cap(packet_list& p_list, volatile bool& quit) {
 		capture_dispatch(p_list);
 	}
 }
-

--- a/src/cap_mgr.h
+++ b/src/cap_mgr.h
@@ -38,6 +38,7 @@ namespace nettop {
 		cap_mgr& operator=(const cap_mgr&) = delete;
 
 		pcap_t	*p_;
+		int	link_type_;
 public:
 		cap_mgr();
 
@@ -51,4 +52,3 @@ public:
 
 
 #endif //_CAP_MGR_H_
-

--- a/src/epoll_stdin.h
+++ b/src/epoll_stdin.h
@@ -20,40 +20,33 @@
 #ifndef _EPOLL_STDIN_
 #define _EPOLL_STDIN_
 
-#include <sys/epoll.h>
+#include <poll.h>
 #include <unistd.h>
+#include <cerrno>
+#include <cstring>
 #include "utils.h"
 
 namespace utils {
 
 	class epoll_stdin {
-		int	efd_;
 	public:
-		epoll_stdin() : efd_(epoll_create1(0)) {
-			if(-1 == efd_)
-				throw nettop::runtime_error("Can't created epoll fd: ") << strerror(errno);
-			// add stdin
-			struct epoll_event event = {0};
-    			event.events = EPOLLIN|EPOLLPRI|EPOLLERR;
-    			event.data.fd = STDIN_FILENO;
-    			if(epoll_ctl(efd_, EPOLL_CTL_ADD, STDIN_FILENO, &event)) {
-				close(efd_);
-				throw nettop::runtime_error("Can't add STDIN to epoll fd: ") << strerror(errno);
-			}
+		epoll_stdin() {
 		}
 
 		// return true when need to do a refresh
 		bool do_io(const size_t msec_tmout) {
-			struct epoll_event	event = {0};
-			const int		fds = epoll_wait(efd_, &event, 1, msec_tmout);
-			if(0 == fds) return false;
+			struct pollfd	pfd = {0};
+			pfd.fd = STDIN_FILENO;
+			pfd.events = POLLIN|POLLPRI|POLLERR;
+			const int	fds = poll(&pfd, 1, msec_tmout);
+			if(0 == fds)
+				return false;
 			else if (0 > fds) {
 				if(EINTR == errno)
 					return false;
-				throw nettop::runtime_error("Error in epoll_wait: ") << strerror(errno);
+				throw nettop::runtime_error("Error in poll: ") << strerror(errno);
 			}
-			// we can only get 1 event at max...
-			if (event.data.fd == STDIN_FILENO) {
+			if (pfd.revents & (POLLIN|POLLPRI|POLLERR)) {
 				char		buf[128];
             			// read input line
             			const int	rb = read(STDIN_FILENO, &buf, 128);
@@ -67,11 +60,9 @@ namespace utils {
 		virtual bool on_data(const char* p, const size_t sz) const = 0;
 
 		virtual ~epoll_stdin() {
-			close(efd_);
 		}
 	};
 
 }
 
 #endif //_EPOLL_STDIN_
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,12 +23,14 @@
 #include <algorithm>
 #include <curses.h>
 #include <csignal>
+#include <clocale>
+#include <cstring>
 #include "utils.h"
 #include "cap_mgr.h"
 #include "proc.h"
 #include "name_res.h"
 #include "settings.h"
-#include "epoll_stdin.h"
+#include "poll_stdin.h"
 
 namespace {
 	volatile bool			quit = false,
@@ -40,6 +42,13 @@ namespace {
 	}
 
 	const char*			__version__ = "0.5";
+
+	const char* host_ip_prefix(void) {
+		const char*	locale = std::setlocale(LC_CTYPE, 0);
+		if(locale && (std::strstr(locale, "UTF-8") || std::strstr(locale, "utf-8") || std::strstr(locale, "UTF8") || std::strstr(locale, "utf8")))
+			return "   \xE2\x86\xB3 ";
+		return "   -> ";
+	}
 
 	struct ps_sorted_iter {
 		nettop::ps_vec::const_iterator					it_p_vec;
@@ -189,6 +198,8 @@ namespace {
 				// print each server txn
 				size_t	cur_hosts = 0;
 				for(const auto& sp_j : sp_i->v_it_addr) {
+					if(cur_row >= row-1)
+						break;
 					if(limit_hosts_ && cur_hosts >= limit_hosts_) {
 						attron(A_DIM);
 						mvprintw(cur_row++, 0, "           ...");
@@ -204,12 +215,21 @@ namespace {
 					if(tot_t) {
 						std::snprintf(tcp_udp_buf, 32, "[%3lu/%3lu] ", tcp_p, udp_p);
 					}
+					const std::string	host_name = nr_.to_str(j.first),
+								host_ip = j.first.to_str();
+					const bool		show_host_ip = nettop::settings::SHOW_HOST_IP && host_name != host_ip;
 					char		buf[256];
-					std::snprintf(buf, 256, "%s%s", (nettop::settings::TCP_UDP_TRAFFIC) ? tcp_udp_buf : "", nr_.to_str(j.first).c_str());
+					std::snprintf(buf, 256, "%s%s", (nettop::settings::TCP_UDP_TRAFFIC) ? tcp_udp_buf : "", host_name.c_str());
 					std::string	r_host = buf; r_host.resize(host_line);
 					recv_send_format(tm_elapsed, j.second.recv, j.second.sent, r_d, s_d, fmt);
 					attron(A_DIM);
 					mvprintw(cur_row++, 0, "           %-*s %10.2f %10.2f  %-5s", host_line, r_host.c_str(), r_d, s_d, fmt);
+					if(show_host_ip && cur_row < row-1) {
+						char	ip_buf[256];
+						std::snprintf(ip_buf, 256, "%s%s", host_ip_prefix(), host_ip.c_str());
+						std::string	r_ip = ip_buf; r_ip.resize(host_line);
+						mvprintw(cur_row++, 0, "           %-*s", host_line, r_ip.c_str());
+					}
 					attroff(A_DIM);
 					++cur_hosts;
 				}
@@ -233,7 +253,7 @@ namespace {
 		curses_setup::MBPS[] = "MiB/s ",
 		curses_setup::GBPS[] = "GiB/s ";
 
-	struct stdin_exit : public utils::epoll_stdin {
+	struct stdin_exit : public utils::poll_stdin {
 		virtual bool on_data(const char* p, const size_t sz) const {
 			for(size_t i = 0; i < sz; ++i) {
 				switch(p[i]) {
@@ -264,6 +284,7 @@ int main(int argc, char *argv[]) {
 	try {
 		using namespace std::chrono;
 
+		std::setlocale(LC_ALL, "");
 		// setup signal functions
 		std::signal(SIGINT, sign_onexit);
 		std::signal(SIGTERM, sign_onexit);
@@ -282,7 +303,7 @@ int main(int argc, char *argv[]) {
 		// init curses
 		curses_setup			c_window(nr, nettop::settings::LIMIT_HOSTS_ROWS);
 		system_clock::time_point	latest_time = std::chrono::system_clock::now();
-		// initi epoll_stdin
+		// init poll_stdin
 		stdin_exit			ep_exit;
 		// automatically set quit to true when
 		// exiting this scope
@@ -334,4 +355,3 @@ int main(int argc, char *argv[]) {
 		std::cerr << "Unknown exception" << std::endl;
 	}
 }
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,7 +176,7 @@ namespace {
 					tot_sent = 0;
 			// print header
 			attron(A_REVERSE);
-			mvprintw(cur_row++, 0, "%-6s  %-*s  %-9s  %-9s        ", "PID", cmdline_len, "CMDLINE", "RECV", "SENT");
+			mvprintw(cur_row++, 0, "%-6s  %-*s  %-9s  %-9s        ", "PID", (int)cmdline_len, "CMDLINE", "RECV", "SENT");
 			attroff(A_REVERSE);
 			// print each entity
 			for(const auto& sp_i : s_v) {
@@ -193,7 +193,7 @@ namespace {
 				if(cur_row >= row-1)
 					continue;
 				attron(A_BOLD);
-				mvprintw(cur_row++, 0, "%6d  %-*s %10.2f %10.2f  %-5s", i.pid, cmdline_len, r_cmd.c_str(), r_d, s_d, fmt);
+				mvprintw(cur_row++, 0, "%6d  %-*s %10.2f %10.2f  %-5s", i.pid, (int)cmdline_len, r_cmd.c_str(), r_d, s_d, fmt);
 				attroff(A_BOLD);
 				// print each server txn
 				size_t	cur_hosts = 0;
@@ -223,12 +223,12 @@ namespace {
 					std::string	r_host = buf; r_host.resize(host_line);
 					recv_send_format(tm_elapsed, j.second.recv, j.second.sent, r_d, s_d, fmt);
 					attron(A_DIM);
-					mvprintw(cur_row++, 0, "           %-*s %10.2f %10.2f  %-5s", host_line, r_host.c_str(), r_d, s_d, fmt);
+					mvprintw(cur_row++, 0, "           %-*s %10.2f %10.2f  %-5s", (int)host_line, r_host.c_str(), r_d, s_d, fmt);
 					if(show_host_ip && cur_row < row-1) {
 						char	ip_buf[256];
 						std::snprintf(ip_buf, 256, "%s%s", host_ip_prefix(), host_ip.c_str());
 						std::string	r_ip = ip_buf; r_ip.resize(host_line);
-						mvprintw(cur_row++, 0, "           %-*s", host_line, r_ip.c_str());
+						mvprintw(cur_row++, 0, "           %-*s", (int)host_line, r_ip.c_str());
 					}
 					attroff(A_DIM);
 					++cur_hosts;
@@ -242,7 +242,7 @@ namespace {
 			char	total_buf[128];
 			snprintf(total_buf, 128, "%s [%5.2fs (%5lu/%5lu/%5lu/%5lu/%5lu)]", 
 				__version__, 1.0*tm_elapsed.count()/1000000000.0, st.total_pkts, st.total_pkts-st.proc_pkts, st.undet_pkts, st.unmap_r_pkts, st.unmap_s_pkts);
-			mvprintw(0, 0, "nettop %-*s", cmdline_len-6, total_buf);
+			mvprintw(0, 0, "nettop %-*s", (int)(cmdline_len-6), total_buf);
 			mvprintw(0, cmdline_len+1, "  Total %10.2f %10.2f  %-5s", r_d, s_d, fmt);
 			refresh();
 		}

--- a/src/poll_stdin.h
+++ b/src/poll_stdin.h
@@ -17,8 +17,8 @@
 *	along with nettop.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _EPOLL_STDIN_
-#define _EPOLL_STDIN_
+#ifndef _POLL_STDIN_
+#define _POLL_STDIN_
 
 #include <poll.h>
 #include <unistd.h>
@@ -28,9 +28,9 @@
 
 namespace utils {
 
-	class epoll_stdin {
+	class poll_stdin {
 	public:
-		epoll_stdin() {
+		poll_stdin() {
 		}
 
 		// return true when need to do a refresh
@@ -59,10 +59,10 @@ namespace utils {
 
 		virtual bool on_data(const char* p, const size_t sz) const = 0;
 
-		virtual ~epoll_stdin() {
+		virtual ~poll_stdin() {
 		}
 	};
 
 }
 
-#endif //_EPOLL_STDIN_
+#endif //_POLL_STDIN_

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -81,9 +81,9 @@ namespace {
         		if (entry->d_type == DT_DIR)
 				continue;
 			// prepare and read the sym link
-			char		cur_sd[128],
+			char		cur_sd[320],
 					buf_sd[128];
-			std::snprintf(cur_sd, 128, "/proc/%i/fd/%s", pid, entry->d_name);
+			std::snprintf(cur_sd, sizeof(cur_sd), "/proc/%i/fd/%s", pid, entry->d_name);
 			const size_t rb = readlink(cur_sd, buf_sd, 128);
 			if(rb >= 128)
 				buf_sd[127] = '\0';

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -32,9 +32,16 @@
 #include <map>
 #include <set>
 #include <sstream>
+#ifdef __APPLE__
+#include <libproc.h>
+#include <netinet/in.h>
+#include <sys/proc_info.h>
+#include <sys/socket.h>
+#endif
 
 namespace {
 
+#ifndef __APPLE__
 	/* Parses /proc/<pid>/cmdline */
 	std::string get_cmd_line(const pid_t pid) {
 		char		cur_fd[64];
@@ -170,6 +177,78 @@ namespace {
 		for(auto& i : out)
 			std::sort(i.second.begin(), i.second.end());
 	}
+#else
+	std::string get_cmd_line(const pid_t pid) {
+		char	path[PROC_PIDPATHINFO_MAXSIZE] = {0};
+		if(proc_pidpath(pid, path, sizeof(path)) > 0)
+			return path;
+		char	name[256] = {0};
+		if(proc_name(pid, name, sizeof(name)) > 0)
+			return name;
+		return "(no cmd line)";
+	}
+
+	inline bool get_local_addr(const struct in_sockinfo& ini, addr_t& out) {
+		if(ini.insi_vflag & INI_IPV4) {
+			out = addr_t(ini.insi_laddr.ina_46.i46a_addr4);
+			return true;
+		}
+		if(ini.insi_vflag & INI_IPV6) {
+			out = addr_t(ini.insi_laddr.ina_6);
+			return true;
+		}
+		return false;
+	}
+
+	inline bool add_socket_fd(const struct socket_fdinfo& sfi, nettop::sd_vec& out) {
+		const struct socket_info&	si = sfi.psi;
+		const struct in_sockinfo		*ini = 0;
+		nettop::packet_stats::type	t = nettop::packet_stats::type::PACKET_TCP;
+		if(si.soi_family != AF_INET && si.soi_family != AF_INET6)
+			return false;
+		if(si.soi_protocol == IPPROTO_TCP || si.soi_kind == SOCKINFO_TCP) {
+			ini = &si.soi_proto.pri_tcp.tcpsi_ini;
+			t = nettop::packet_stats::type::PACKET_TCP;
+		} else if(si.soi_protocol == IPPROTO_UDP || (si.soi_kind == SOCKINFO_IN && si.soi_type == SOCK_DGRAM)) {
+			ini = &si.soi_proto.pri_in;
+			t = nettop::packet_stats::type::PACKET_UDP;
+		} else {
+			return false;
+		}
+
+		addr_t	addr;
+		if(!get_local_addr(*ini, addr))
+			return false;
+		const int port = ntohs((uint16_t)ini->insi_lport);
+		if(port <= 0)
+			return false;
+		out.push_back(nettop::ext_sd(addr, port, t));
+		return true;
+	}
+
+	void get_sockets_for_pid(const pid_t pid, nettop::sd_vec& out) {
+		const int fds_sz = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, 0, 0);
+		if(fds_sz <= 0)
+			return;
+		std::vector<struct proc_fdinfo> fds((fds_sz/sizeof(struct proc_fdinfo)) + 1);
+		const int fds_ret = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, fds.data(), fds.size()*sizeof(struct proc_fdinfo));
+		if(fds_ret <= 0)
+			return;
+		const size_t fds_count = fds_ret/sizeof(struct proc_fdinfo);
+		for(size_t i = 0; i < fds_count; ++i) {
+			if(fds[i].proc_fdtype != PROX_FDTYPE_SOCKET)
+				continue;
+			struct socket_fdinfo sfi;
+			std::memset(&sfi, 0x00, sizeof(sfi));
+			const int sfi_ret = proc_pidfdinfo(pid, fds[i].proc_fd, PROC_PIDFDSOCKETINFO, &sfi, sizeof(sfi));
+			if(sfi_ret < (int)sizeof(sfi))
+				continue;
+			add_socket_fd(sfi, out);
+		}
+		std::sort(out.begin(), out.end());
+		out.erase(std::unique(out.begin(), out.end()), out.end());
+	}
+#endif
 
 	// async log events
 	struct log_evt : public nettop::async_line {
@@ -209,6 +288,7 @@ namespace {
 }
 
 nettop::proc_mgr::proc_mgr() {
+#ifndef __APPLE__
 	// get all the links between ext_sd --> inode
 	m_inodes	inodes_link;
 	get_all_sockets(inodes_link);
@@ -257,6 +337,27 @@ nettop::proc_mgr::proc_mgr() {
 		p_map_[proc_info(pid, cmd_line, sds)];
     	}
     	closedir(dir);
+#else
+	const int pids_hint = proc_listallpids(0, 0);
+	if(pids_hint <= 0)
+		return;
+	std::vector<pid_t>	pids((size_t)pids_hint + 1024);
+	const int pids_ret = proc_listallpids(pids.data(), pids.size()*sizeof(pid_t));
+	if(pids_ret <= 0)
+		return;
+	const size_t pids_count = std::min((size_t)pids_ret, pids.size());
+	for(size_t i = 0; i < pids_count; ++i) {
+		const pid_t	pid = pids[i];
+		if(pid <= 0)
+			continue;
+		sd_vec		sds;
+		get_sockets_for_pid(pid, sds);
+		if(sds.empty())
+			continue;
+		const std::string	cmd_line = get_cmd_line(pid);
+		p_map_[proc_info(pid, cmd_line, sds)];
+	}
+#endif
 }
 
 //#include <iostream>
@@ -367,4 +468,3 @@ void nettop::proc_mgr::bind_packets(const std::list<packet_stats>& p_list, const
 		out.push_back(ps);
 	}
 }
-

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -35,6 +35,7 @@ namespace {
 				"    --filter-zero\t\tSet to filter all zero results (default not set)\n"
 				"    --tcp-udp-split\t\tDisplays split of TCP and UDP traffic in % (default not set)\n"
 				"-n, --no-resolve\t\tDo not resolve addresses, leave IPs to be displayed\n"
+				"    --show-host-ip\t\tDisplay numeric IP below resolved host names (default not set)\n"
 				"-a, --async-log-file (file)\tSets an output file where to store the packets attribued to the 'kernel' (default not set)\n"
 				"-i, --interface (iface)\t\tCapture on a specific network interface (default auto)\n"
 				"-l, --limit-hosts-rows\t\tLimits maximum number of hosts rows per pid (default no limit)\n"
@@ -52,6 +53,7 @@ namespace nettop {
 		bool		FILTER_ZERO = false;
 		bool		TCP_UDP_TRAFFIC = false;
 		bool		NO_RESOLVE = false;
+		bool		SHOW_HOST_IP = false;
 		std::string	ASYNC_LOG_FILE = "";
 		std::string	INTERFACE = "";
 		size_t		LIMIT_HOSTS_ROWS = 0;
@@ -70,6 +72,7 @@ int nettop::parse_args(int argc, char *argv[], const char *prog, const char *ver
 		{"no-resolve",		no_argument,       0,	'n'},
 		{"filter-zero",		no_argument, 	   0,	0},
 		{"tcp-udp-split",	no_argument,	   0,	0},
+		{"show-host-ip",	no_argument,	   0,	0},
 		{"async-log-file",	required_argument, 0,	'a'},
 		{"interface",		required_argument, 0,	'i'},
 		{"limit-hosts-rows",	required_argument, 0,	'l'},
@@ -90,8 +93,10 @@ int nettop::parse_args(int argc, char *argv[], const char *prog, const char *ver
                 		break;
 			if(!std::strcmp("filter-zero", long_options[option_index].name)) {
 				FILTER_ZERO = true;
-			} if(!std::strcmp("tcp-udp-split", long_options[option_index].name)) {
+			} else if(!std::strcmp("tcp-udp-split", long_options[option_index].name)) {
 				TCP_UDP_TRAFFIC = true;
+			} else if(!std::strcmp("show-host-ip", long_options[option_index].name)) {
+				SHOW_HOST_IP = true;
 			} else if(!std::strcmp("help", long_options[option_index].name)) {
 				print_help(prog, version);
 				std::exit(0);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -36,6 +36,7 @@ namespace {
 				"    --tcp-udp-split\t\tDisplays split of TCP and UDP traffic in % (default not set)\n"
 				"-n, --no-resolve\t\tDo not resolve addresses, leave IPs to be displayed\n"
 				"-a, --async-log-file (file)\tSets an output file where to store the packets attribued to the 'kernel' (default not set)\n"
+				"-i, --interface (iface)\t\tCapture on a specific network interface (default auto)\n"
 				"-l, --limit-hosts-rows\t\tLimits maximum number of hosts rows per pid (default no limit)\n"
 				"    --help\t\t\tprints this help and exit\n\n"
 				"Press 'q' or 'ESC' inside nettop to quit, 'SPACE' or 'p' to pause nettop\n"
@@ -52,6 +53,7 @@ namespace nettop {
 		bool		TCP_UDP_TRAFFIC = false;
 		bool		NO_RESOLVE = false;
 		std::string	ASYNC_LOG_FILE = "";
+		std::string	INTERFACE = "";
 		size_t		LIMIT_HOSTS_ROWS = 0;
 	}
 }
@@ -69,6 +71,7 @@ int nettop::parse_args(int argc, char *argv[], const char *prog, const char *ver
 		{"filter-zero",		no_argument, 	   0,	0},
 		{"tcp-udp-split",	no_argument,	   0,	0},
 		{"async-log-file",	required_argument, 0,	'a'},
+		{"interface",		required_argument, 0,	'i'},
 		{"limit-hosts-rows",	required_argument, 0,	'l'},
 		{0, 0, 0, 0}
 	};
@@ -77,7 +80,7 @@ int nettop::parse_args(int argc, char *argv[], const char *prog, const char *ver
         	// getopt_long stores the option index here
         	int		option_index = 0;
 
-		if(-1 == (c = getopt_long(argc, argv, "hr:c:o:a:l:n", long_options, &option_index)))
+		if(-1 == (c = getopt_long(argc, argv, "hr:c:o:a:i:l:n", long_options, &option_index)))
        			break;
 
 		switch (c) {
@@ -132,6 +135,10 @@ int nettop::parse_args(int argc, char *argv[], const char *prog, const char *ver
 			ASYNC_LOG_FILE = optarg;
 		} break;
 
+		case 'i': {
+			INTERFACE = optarg;
+		} break;
+
 		case 'l': {
 			const int	m_res = std::atoi(optarg);
 			LIMIT_HOSTS_ROWS = (m_res > 0) ? m_res : 0;
@@ -152,4 +159,3 @@ int nettop::parse_args(int argc, char *argv[], const char *prog, const char *ver
 
 	return optind;
 }
-

--- a/src/settings.h
+++ b/src/settings.h
@@ -36,6 +36,7 @@ namespace nettop {
 		extern bool		TCP_UDP_TRAFFIC;
 		extern bool		NO_RESOLVE;
 		extern std::string	ASYNC_LOG_FILE;
+		extern std::string	INTERFACE;
 		extern size_t		LIMIT_HOSTS_ROWS;
 	}
 
@@ -43,4 +44,3 @@ namespace nettop {
 }
 
 #endif //_SETTINGS_H_
-

--- a/src/settings.h
+++ b/src/settings.h
@@ -35,6 +35,7 @@ namespace nettop {
 		extern bool		FILTER_ZERO;
 		extern bool		TCP_UDP_TRAFFIC;
 		extern bool		NO_RESOLVE;
+		extern bool		SHOW_HOST_IP;
 		extern std::string	ASYNC_LOG_FILE;
 		extern std::string	INTERFACE;
 		extern size_t		LIMIT_HOSTS_ROWS;


### PR DESCRIPTION
## Summary

Adds macOS support for nettop while preserving the existing Linux implementation.

This change makes the project build and run on Apple Silicon Macs by replacing Linux-only APIs where needed and adding Darwin-specific process/socket discovery.

## Changes

- Replace `epoll`-based stdin polling with portable `poll(2)`
- Add macOS packet parsing support for Ethernet, loopback, and raw IP datalink types
- Keep Linux cooked socket capture support intact
- Add macOS process/socket mapping via `libproc`
- Add `--interface` / `-i` option so users can select interfaces like `en0` or `lo0`
- Link `libproc` automatically on Darwin builds
- Update README with macOS build and runtime notes

## Testing

- Built successfully with:

  ```bash
  make release
  
  Verified help output:

./nettop --help

Verified macOS permission behavior when running without sufficient BPF access.